### PR TITLE
TT-107: Update User Type

### DIFF
--- a/src/Contexts/AuthContext.tsx
+++ b/src/Contexts/AuthContext.tsx
@@ -29,7 +29,7 @@ interface AuthContextState{
 export const AuthContextContextProvider = ({children}: any) => {
     //TODO REMOVE THESE WHEN BACKEND WORKING -- pass whichever is needed into the initial state of user/setUser useState
     const dummyClientUser : User = {
-        username: "client1",
+        userId: 1,
         firstname: "Adam",
         lastname: "Adams",
         email: "adam@adam.com",
@@ -45,7 +45,7 @@ export const AuthContextContextProvider = ({children}: any) => {
     }
 
     const dummyProfessionalUser : User = {
-        username: "professional1",
+        userId: 2,
         firstname: "Bob",
         lastname: "Bobby",
         email: "bob@bob.com",

--- a/src/Pages/SignUp/SignUp.tsx
+++ b/src/Pages/SignUp/SignUp.tsx
@@ -13,7 +13,6 @@ const phoneRegExp = /^((\\+[1-9]{1,4}[ \\-]*)|(\\([0-9]{2,3}\\)[ \\-]*)|([0-9]{2
 const numericRegExp = /^\d+$/;
 
 const SignUpSchema = Yup.object().shape({
-    username: Yup.string().required("Username is required"),
     firstname: Yup.string().required("First name is required"),
     lastname: Yup.string().required("Last name is required"),
     email: Yup.string()
@@ -44,7 +43,6 @@ const SignUpSchema = Yup.object().shape({
 });
 
 export interface SignUpFields {
-    username: string;
     firstname: string;
     lastname: string;
     email: string;
@@ -84,7 +82,6 @@ export const SignUp = () => {
     const [currentStep, setCurrentStep] = useState<number>(0);
 
     const initialValues: SignUpFields = {
-        username: "",
         firstname: "",
         lastname: "",
         email: "",

--- a/src/Pages/SignUp/SignUpWizard/UserDetails.tsx
+++ b/src/Pages/SignUp/SignUpWizard/UserDetails.tsx
@@ -20,16 +20,16 @@ export const UserDetails = ({setCurrentStep}: SignUpProps) => {
     const {errors, values, touched, getFieldProps} = useFormikContext();
 
     function stepsComplete() {
-        return ((errors as SignUpFields).username === undefined) &&
+        return (
             ((errors as SignUpFields).firstname === undefined) &&
             ((errors as SignUpFields).lastname === undefined) &&
             ((errors as SignUpFields).email === undefined) &&
             ((errors as SignUpFields).mobile === undefined) &&
-            ((values as SignUpFields).username !== "") &&
             ((values as SignUpFields).firstname !== "") &&
             ((values as SignUpFields).lastname !== "") &&
             ((values as SignUpFields).email !== "") &&
-            ((values as SignUpFields).mobile !== "");
+            ((values as SignUpFields).mobile !== "")
+        );
     }
 
     function emailValid() {
@@ -67,16 +67,6 @@ export const UserDetails = ({setCurrentStep}: SignUpProps) => {
                             initial={{opacity: 0, y: 40}}
                             animate={animate}
                         >
-                            <ThemedTextField
-                                fullWidth
-                                autoComplete="username"
-                                type="username"
-                                label="Username"
-                                required
-                                error={Boolean((touched as SignUpFields).username && (errors as SignUpFields).username)}
-                                helperText={(touched as SignUpFields).username && (errors as SignUpFields).username}
-                                {...getFieldProps("username")}
-                            />
                             <ThemedTextField
                                 fullWidth
                                 autoComplete="first name"
@@ -166,7 +156,7 @@ export const UserDetails = ({setCurrentStep}: SignUpProps) => {
                                         //Clear alerts
                                         setAlert(<></>);
 
-                                        //TODO need to hit endpoint to check username is not taken, and set alert if it is
+                                        //TODO need to hit endpoint to check email is not taken, and set alert if it is
 
                                         setCurrentStep(1);
                                     } else {

--- a/src/Types/User.ts
+++ b/src/Types/User.ts
@@ -4,7 +4,7 @@ import {UserType} from "./Account";
  * Interface to describe the attributes of User
  */
 export interface User {
-    username: string;
+    userId: number;
     firstname: string;
     lastname: string;
     email: string;


### PR DESCRIPTION
Following criteria for TT-107:
1. User type should not have a username, but should have a user ID
2. The user ID shouldn't be selected by the user in the sign up portion, as the user ID is generated by the backend upon successful user creation, and returned to the frontend