### PR TITLE
Available Requests Page for Professionals

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import SignUp from "./Pages/SignUp/SignUp";
 import EditProfile from './Pages/UserProfile/EditProfile';
 import {RequestHistory} from "./Pages/RequestHistory/RequestHistory";
 import ProfessionalProfileDisplay from "./Pages/ProfessionalProfile/ProfessionalProfileDisplay";
-
+import {AvailableRequests} from "./Pages/AvailableRequests/AvailableRequests";
 
 function App() {
     return (
@@ -27,6 +27,7 @@ function App() {
                         <Route path={RoutesEnum.USER_MANAGEMENT} element={<UserProfileDisplay />}/>
                         <Route path={RoutesEnum.REQUEST_HISTORY} element={<RequestHistory />}/>
                         <Route path={RoutesEnum.CREATE_REQUEST} element={<CreateRequest />} />
+                        <Route path={RoutesEnum.AVAILABLE_REQUESTS} element={<AvailableRequests />} />
                         <Route path={RoutesEnum.PASSWORD} element={<Password/>}/>
                         <Route path={RoutesEnum.EDIT_PROFILE} element={<EditProfile/>}/>
                         <Route path={RoutesEnum.Pro_Profile} element={<ProfessionalProfileDisplay />}/>

--- a/src/Contexts/AuthContext.tsx
+++ b/src/Contexts/AuthContext.tsx
@@ -26,40 +26,40 @@ interface AuthContextState{
     setRefreshToken?: (token: string) => void;
 }
 
+//TODO REMOVE THESE WHEN BACKEND WORKING -- pass whichever is needed into the initial state of user/setUser useState
+const dummyClientUser : User = {
+    userId: 1,
+    firstname: "Adam",
+    lastname: "Adams",
+    email: "adam@adam.com",
+    password: "adam",
+    address: {
+        streetNumber: "1",
+        streetName: "Adamson Street",
+        postcode: "2170",
+        suburb: "Liverpool"
+    },
+    mobile: "0411222333",
+    usertype: UserType.CLIENT
+}
+
+export const dummyProfessionalUser : User = {
+    userId: 2,
+    firstname: "Bob",
+    lastname: "Bobby",
+    email: "bob@bob.com",
+    password: "bob",
+    address: {
+        streetNumber: "2",
+        streetName: "Bobby Street",
+        postcode: "2170",
+        suburb: "Liverpool"
+    },
+    mobile: "0499888777",
+    usertype: UserType.PROFESSIONAL
+}
+
 export const AuthContextContextProvider = ({children}: any) => {
-    //TODO REMOVE THESE WHEN BACKEND WORKING -- pass whichever is needed into the initial state of user/setUser useState
-    const dummyClientUser : User = {
-        userId: 1,
-        firstname: "Adam",
-        lastname: "Adams",
-        email: "adam@adam.com",
-        password: "adam",
-        address: {
-            streetNumber: "1",
-            streetName: "Adamson Street",
-            postcode: "2170",
-            suburb: "Liverpool"
-        },
-        mobile: "0411222333",
-        usertype: UserType.CLIENT
-    }
-
-    const dummyProfessionalUser : User = {
-        userId: 2,
-        firstname: "Bob",
-        lastname: "Bobby",
-        email: "bob@bob.com",
-        password: "bob",
-        address: {
-            streetNumber: "2",
-            streetName: "Bobby Street",
-            postcode: "2170",
-            suburb: "Liverpool"
-        },
-        mobile: "0499888777",
-        usertype: UserType.PROFESSIONAL
-    }
-
     /**
      * Current state of user
      */

--- a/src/Pages/AvailableRequests/AvailableRequests.tsx
+++ b/src/Pages/AvailableRequests/AvailableRequests.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import PageContainer from "../../Components/PageContainer/PageContainer";
+import AvailableRequestsTable from "./AvailableRequestsTable/AvailableRequestsTable";
+
+/**
+ * Page to display the available {@link ServiceRequest}s for a professionl {@link User} to pick up
+ */
+export const AvailableRequests = (): JSX.Element => {
+
+    return (
+        <PageContainer title={'Available Requests'}>
+            <AvailableRequestsTable />
+        </PageContainer>
+    )
+}
+
+export default AvailableRequests;

--- a/src/Pages/AvailableRequests/AvailableRequestsTable/ApplicationConfirmationDialog/ApplicationConfirmationDialog.tsx
+++ b/src/Pages/AvailableRequests/AvailableRequestsTable/ApplicationConfirmationDialog/ApplicationConfirmationDialog.tsx
@@ -1,0 +1,109 @@
+import React, {useState} from 'react';
+import {ServiceRequest} from "../../../../Types/ServiceRequest";
+import {Dialog, DialogActions, DialogContent, DialogTitle, Grid, Typography} from "@mui/material";
+import {format} from "date-fns";
+import {ThemedButton} from "../../../../Components/Button/ThemedButton";
+import ThemedTextField from "../../../../Components/TextField/ThemedTextField";
+
+export interface ApplicationConfirmationDialogProps {
+    /**
+     * The {@link ServiceRequest} that is being applied for
+     */
+    request: ServiceRequest;
+
+    /**
+     * Callback to set the open/close status of the {@link ApplicationConfirmationDialog}
+     */
+    setShowConfirmationDialog: (isOpen: boolean) => void;
+
+    /**
+     * Boolean flgag to indicate whether the {@link ApplicationConfirmationDialog} should be visible
+     */
+    showConfirmationDialog: boolean;
+}
+
+export const ApplicationConfirmationDialog = ({
+                                                  request,
+                                                  setShowConfirmationDialog,
+                                                  showConfirmationDialog
+                                              }: ApplicationConfirmationDialogProps) => {
+    const [requestCharge, setRequestCharge] = useState<string>('');
+    console.log()
+    return (
+        <Dialog open={showConfirmationDialog}>
+            <div style={{backgroundColor: "#D8CECD", padding: "12px"}}>
+                <DialogTitle id={"application-confirmation__dialog"} sx={{fontWeight: "light", fontSize: "40px"}}>
+                    {"Apply for Request"}
+                </DialogTitle>
+                <DialogContent>
+                    <Grid container spacing={4} marginBottom={2}>
+                        <Grid item>
+                            <Typography fontWeight={'bold'}>Application Number:</Typography>
+                        </Grid>
+                        <Grid item>
+                            <Typography>{`${request.applicationNumber}`}</Typography>
+                        </Grid>
+                    </Grid>
+                    <Grid container spacing={7} marginBottom={2}>
+                        <Grid item>
+                            <Typography fontWeight={'bold'}>Application Date:</Typography>
+                        </Grid>
+                        <Grid item>
+                            <Typography>{`${format(request.applicationDate, 'dd/MM/yyyy')}`}</Typography>
+                        </Grid>
+                    </Grid>
+                    <Grid container spacing={11} marginBottom={2}>
+                        <Grid item>
+                            <Typography fontWeight={'bold'}>Service Type:</Typography>
+                        </Grid>
+                        <Grid item>
+                            <Typography>{`${request.serviceType}`}</Typography>
+                        </Grid>
+                    </Grid>
+                    <Grid container spacing={19} marginBottom={2}>
+                        <Grid item>
+                            <Typography fontWeight={'bold'}>Cost:</Typography>
+                        </Grid>
+                        <Grid item>
+                            <ThemedTextField
+                                required
+                                size={"small"}
+                                value={requestCharge}
+                                error={(requestCharge !== '') && (isNaN(Number(requestCharge)))}
+                                helperText={(requestCharge !== '') && isNaN(Number(requestCharge)) && 'Cost should be a numeric value'}
+                                onChange={(event) => setRequestCharge(event.target.value)}
+                            />
+                        </Grid>
+                    </Grid>
+                    <Grid container spacing={2} marginBottom={2}>
+                        <Grid item>
+                            <Typography fontWeight={'bold'}>Additional Description:</Typography>
+                        </Grid>
+                        <Grid item>
+                            {<Typography>{request.description ? `${request.description}` : '-'}</Typography>}
+                        </Grid>
+                    </Grid>
+                </DialogContent>
+                <DialogActions sx={{gap: 2}}>
+                    <ThemedButton
+                        onClick={() => {
+                            setShowConfirmationDialog(false);
+
+                        }}
+                        variant={'text'}
+                    >
+                        Cancel
+                    </ThemedButton>
+                    {/*TODO add onClick functionality to submit an application to the service request*/}
+                    <ThemedButton
+                        onClick={() => setShowConfirmationDialog(false)}
+                        autoFocus
+                        disabled={(isNaN(Number(requestCharge)) || (requestCharge === ''))}
+                    >
+                        Confirm
+                    </ThemedButton>
+                </DialogActions>
+            </div>
+        </Dialog>
+    )
+}

--- a/src/Pages/AvailableRequests/AvailableRequestsTable/AvailableRequestsTable.module.css
+++ b/src/Pages/AvailableRequests/AvailableRequestsTable/AvailableRequestsTable.module.css
@@ -1,0 +1,3 @@
+.table-container {
+    margin: 2rem 3rem 0 1rem;
+}

--- a/src/Types/ServiceRequest.ts
+++ b/src/Types/ServiceRequest.ts
@@ -38,6 +38,10 @@ export interface ServiceRequest {
      */
     professional?: User;
     /**
+     * (Optional) List of Professional {@link User} id's who have applied for the job listing
+     */
+    applicantIds?: number[];
+    /**
      * Cost if a Client is on {@link MembershipOption.PAY_AS_YOU_GO}
      */
     cost: number;

--- a/src/Types/User.ts
+++ b/src/Types/User.ts
@@ -1,4 +1,4 @@
-import {UserType} from "./Account";
+import {MembershipOption, UserType} from "./Account";
 
 /**
  * Interface to describe the attributes of User
@@ -11,7 +11,14 @@ export interface User {
     password: string;
     address: Address;
     mobile: string;
+    /**
+     * Client vs. Professional
+     */
     usertype: UserType;
+    /**
+     Optional {@link MembershipOption} if the user is a Client
+     */
+    membershipOption?: MembershipOption;
 }
 
 export interface Address {

--- a/src/Utilities/GenerateDummyData.tsx
+++ b/src/Utilities/GenerateDummyData.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import {User} from "../Types/User";
-import {UserType} from "../Types/Account";
+import {MembershipOption, UserType} from "../Types/Account";
 import {ServiceRequest, ServiceRequestStatus} from "../Types/ServiceRequest";
 import {ServiceType} from "../Types/ServiceType";
+import {dummyProfessionalUser} from "../Contexts/AuthContext";
 
 /**
  * Function to generate a list of dummy data containing a list of clients
@@ -10,7 +11,8 @@ import {ServiceType} from "../Types/ServiceType";
 export function generateClients() : User[] {
     let clients : User[] = [];
 
-    for(let i=1; i<51; i++) {
+    //Starting from 3 as ids 1 and 2 are in the AuthContext
+    for(let i=3; i<51; i++) {
         const newClient : User = {
             userId: i,
             firstname: `Firstname ${i}`,
@@ -24,7 +26,8 @@ export function generateClients() : User[] {
                 postcode: `12${i}`
             },
             mobile: `12345678${i}`,
-            usertype: UserType.CLIENT
+            usertype: UserType.CLIENT,
+            membershipOption: (i%2 === 0) ? MembershipOption.SUBSCRIPTION : MembershipOption.PAY_AS_YOU_GO
         }
 
         clients.push(newClient);
@@ -86,7 +89,8 @@ const dummyServiceRequests : ServiceRequest[] = [
         postcode: "2444",
         client: generateClients().at(0) as User,
         suburb: "Sydney",
-        cost: 0
+        cost: 0,
+        description: 'The tree is in the way'
     },
     {
         applicationNumber: 6,
@@ -94,6 +98,7 @@ const dummyServiceRequests : ServiceRequest[] = [
         serviceType: ServiceType.PLUMBING,
         status: ServiceRequestStatus.NEW,
         client: generateClients().at(0) as User,
+        applicantIds: [dummyProfessionalUser.userId],       //Pretending this has already had 1 applicant - this dummyProfessionalUser
         postcode: "2555",
         suburb: "Moorebank",
         cost: 0
@@ -186,4 +191,8 @@ export function generateProfessionals() : User[] {
  */
 export function generateDummyServiceRequests(showNew: boolean) {
     return !showNew ? dummyServiceRequests.filter((request) => request.status !== ServiceRequestStatus.NEW) : dummyServiceRequests;
+}
+
+export function generateNewDummyServiceRequests() {
+    return dummyServiceRequests.filter((request) => request.status === ServiceRequestStatus.NEW);
 }

--- a/src/Utilities/TableUtils.ts
+++ b/src/Utilities/TableUtils.ts
@@ -1,0 +1,4 @@
+export enum SortDirection {
+    ASC = 'asc',
+    DESC = 'desc'
+}


### PR DESCRIPTION
1. Added page for professionals to view nearby requests
2. Only 'New' requests are shown here
<img width="1508" alt="image" src="https://user-images.githubusercontent.com/126940746/229331431-97b19b3c-602b-44c9-9f32-f1c6bbed3f56.png">
3. If a tradie has applied for a job already, the 'Apply' button is disabled with a tooltip on hover
<img width="294" alt="image" src="https://user-images.githubusercontent.com/126940746/229331439-071c87fe-7d18-4f05-ac3c-2145a4b0995e.png">
4. When applying for a job, if client is pay-as-you-go, the 'Confirm' button is disabled until a cost is entered
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/126940746/229331474-2c65cad7-1d5d-4ba7-8e03-5b290277869b.png">
5. Cost needs to be numeric 
<img width="543" alt="image" src="https://user-images.githubusercontent.com/126940746/229331482-27bcb00e-a18f-42d0-9c93-f054b75352f5.png">
6. When a valid value is entered, button is not disabled and they can submit the application
<img width="545" alt="image" src="https://user-images.githubusercontent.com/126940746/229331496-c870feea-1419-422b-bee6-23b72d7391e4.png">