### PR TITLE
Request History, Available Request, Pro profile Styling

### DIFF
--- a/src/Pages/AvailableRequests/AvailableRequests.tsx
+++ b/src/Pages/AvailableRequests/AvailableRequests.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PageContainer from "../../Components/PageContainer/PageContainer";
 import AvailableRequestsTable from "./AvailableRequestsTable/AvailableRequestsTable";
+import {Box} from "@mui/material";
+import {motion} from "framer-motion";
+import {fadeInUp} from "../../Effects/Animations";
 
 /**
  * Page to display the available {@link ServiceRequest}s for a professionl {@link User} to pick up
@@ -9,7 +12,12 @@ export const AvailableRequests = (): JSX.Element => {
 
     return (
         <PageContainer title={'Available Requests'}>
-            <AvailableRequestsTable />
+            <Box
+                component={motion.div}
+                {...fadeInUp}
+            >
+                <AvailableRequestsTable />
+            </Box>
         </PageContainer>
     )
 }

--- a/src/Pages/ProfessionalProfile/ProfessionalProfile.tsx
+++ b/src/Pages/ProfessionalProfile/ProfessionalProfile.tsx
@@ -14,6 +14,8 @@ import {
     TableRow,
 } from "@mui/material";
 import {User} from "../../Types/User";
+import {motion} from "framer-motion";
+import {fadeInUp} from "../../Effects/Animations";
 
 const StyledTableCell = styled(TableCell)(({theme}) => ({
     [`&.${tableCellClasses.head}`]: {
@@ -65,7 +67,10 @@ export const ProfessionalProfile = () => {
 
     if (user) {
         return (
-            <Box>
+            <Box
+                component={motion.div}
+                {...fadeInUp}
+            >
                 <Box sx={{
                     display: "grid",
                     justifyContent: "center"

--- a/src/Pages/RequestHistory/RequestHistoryTables/RequestHistoryTable.tsx
+++ b/src/Pages/RequestHistory/RequestHistoryTables/RequestHistoryTable.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {
     Alert,
-    Backdrop,
+    Backdrop, Box,
     Table,
     TableBody,
     TableCell,
@@ -29,6 +29,8 @@ import {TableSkeleton} from "../../../Components/TableSkeleton/TableSkeleton";
 import axios from "axios";
 import {CORS_HEADER, DEV_PATH} from "../../../Routes";
 import {InfoOutlined} from "@mui/icons-material";
+import {motion} from "framer-motion";
+import {fadeInUp} from "../../../Effects/Animations";
 
 enum ClientRequestHistoryColumn {
     ApplicationNumber = 'ApplicationNumber',
@@ -324,146 +326,152 @@ export const RequestHistoryTable = (): JSX.Element => {
 
     return (
         <div className={styles['table-container']}>
+            <Box
+                component={motion.div}
+                {...fadeInUp}
+            >
             {alert}
-            <Table>
-                <TableHead>
-                    <TableRow>
-                        {Object.entries(headersToUse).map(([key, value]) => {
-                            return (
-                                <TableCell
-                                    key={key}
-                                    sx={{
-                                        borderRadius: getHeaderBorderRadius(key as ClientRequestHistoryColumn),
-                                        backgroundColor: "#d3733c",
-                                        color: "white"
-                                    }}
-                                >
-                                    {/*Manage and Review columns aren't sortable*/}
-                                    {(key === ClientRequestHistoryColumn.Manage || key === ClientRequestHistoryColumn.Review) ?
-                                        <Typography variant={'h6'} fontWeight={"bold"}>
-                                            {mapColumnName(value)}
-                                        </Typography> :
-                                        <TableSortLabel
-                                            active={sortColumn === key}
-                                            direction={sortColumn === key ? sortDirection : SortDirection.ASC}
-                                            onClick={() => {
-                                                handleSort(key as ProfessionalRequestHistoryColumn)
-                                            }}
-                                        >
-                                            <Typography variant={'h6'} fontWeight={"bold"}>
-                                                {mapColumnName(value)}
-                                            </Typography>
-                                        </TableSortLabel>
-                                    }
-                                </TableCell>
-                            );
-                        })}
-                    </TableRow>
-                </TableHead>
-                <TableBody>
-                    {loading ? (<TableSkeleton columns={user.userType === UserType.PROFESSIONAL ? 9 : 7}/>) : <></>}
-                    {(!loading && rows.length === 0) ?
+                <Table>
+                    <TableHead>
                         <TableRow>
-                            <TableCell/>
-                            <TableCell/>
-                            {user.userType === UserType.PROFESSIONAL && <TableCell/>}
-                            <TableCell>
-                                <Typography>
-                                    There are no service requests for this user.
-                                </Typography>
-                            </TableCell>
-                            <TableCell/>
-                            <TableCell/>
-                            <TableCell/>
-                            <TableCell/>
-                            {user.userType === UserType.PROFESSIONAL && <TableCell/>}
-                        </TableRow> :
-                        <></>
-                    }
-                    {!loading ?
-                        <>
-                            {
-                                rows?.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((request, index) =>
-                                    <TableRow
-                                        key={request.requestID}
+                            {Object.entries(headersToUse).map(([key, value]) => {
+                                return (
+                                    <TableCell
+                                        key={key}
                                         sx={{
-                                            backgroundColor: "white",
-                                            '&:last-child td:first-of-type': {
-                                                borderBottomLeftRadius: 12,
-                                            },
-                                            '&:last-child td:last-child': {
-                                                borderBottomRightRadius: 12,
-                                            },
+                                            borderRadius: getHeaderBorderRadius(key as ClientRequestHistoryColumn),
+                                            backgroundColor: "#d3733c",
+                                            color: "white"
                                         }}
                                     >
-                                        <TableCell>
-                                            {request.requestID}
-                                        </TableCell>
-                                        <TableCell>
-                                            {format(request.requestDate, "dd/MM/yyyy")}
-                                        </TableCell>
-                                        {/*Location column only renders for professionals viewing their confirmed service requests*/}
-                                        {
-                                            user.userType === UserType.PROFESSIONAL &&
-                                            <TableCell>
-                                                <b>{request.postcode}</b>
-                                            </TableCell>
-                                        }
-                                        <TableCell>
-                                            {request.serviceType}
-                                        </TableCell>
-                                        <TableCell>
-                                            <div className={styles['status-cell']}>
-                                                <StatusIcon status={request.requestStatus}/>
-                                                <b>{request.requestStatus}</b>
-                                            </div>
-                                        </TableCell>
-                                        {/*Show client attached to the service request only if we are viewing as a professional*/}
-                                        {
-                                            user.userType === UserType.PROFESSIONAL &&
-                                            <TableCell>
-                                                {request.clientName}
-                                            </TableCell>
-                                        }
-                                        <TableCell>
-                                            {request.applications?.filter((app) => app.professionalID === request.professionalID).at(0) ?
-                                                `$${request.applications?.filter((app) => app.professionalID === request.professionalID).at(0)?.cost}` :
-                                                '-'
-                                            }
-                                        </TableCell>
-                                        <TableCell>
-                                            {/*    Mostly Iteration 3 work - only ability to view existing request implemented in 2 */}
-                                            {/* Iteration 3 will add seeing how many responses from professionals in this cell too, and more conditional rendering */}
-                                            <ThemedButton
-                                                variantOverride={'text'}
+                                        {/*Manage and Review columns aren't sortable*/}
+                                        {(key === ClientRequestHistoryColumn.Manage || key === ClientRequestHistoryColumn.Review) ?
+                                            <Typography variant={'h6'} fontWeight={"bold"}>
+                                                {mapColumnName(value)}
+                                            </Typography> :
+                                            <TableSortLabel
+                                                active={sortColumn === key}
+                                                direction={sortColumn === key ? sortDirection : SortDirection.ASC}
                                                 onClick={() => {
-                                                    setShowRequestSummary(true);
-                                                    setRequestToView(request);
+                                                    handleSort(key as ProfessionalRequestHistoryColumn)
                                                 }}
                                             >
-                                                {
-                                                    (request.requestStatus === ServiceRequestStatus.NEW && user.userType === UserType.CLIENT) && (!request.applications || request.applications?.length === 0)
-                                                        ?
-                                                        `View / Edit` :
-                                                        `View`
+                                                <Typography variant={'h6'} fontWeight={"bold"}>
+                                                    {mapColumnName(value)}
+                                                </Typography>
+                                            </TableSortLabel>
+                                        }
+                                    </TableCell>
+                                );
+                            })}
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {loading ? (<TableSkeleton columns={user.userType === UserType.PROFESSIONAL ? 9 : 7}/>) : <></>}
+                        {(!loading && rows.length === 0) ?
+                            <TableRow>
+                                <TableCell/>
+                                <TableCell/>
+                                {user.userType === UserType.PROFESSIONAL && <TableCell/>}
+                                <TableCell>
+                                    <Typography>
+                                        There are no service requests for this user.
+                                    </Typography>
+                                </TableCell>
+                                <TableCell/>
+                                <TableCell/>
+                                <TableCell/>
+                                <TableCell/>
+                                {user.userType === UserType.PROFESSIONAL && <TableCell/>}
+                            </TableRow> :
+                            <></>
+                        }
+                        {!loading ?
+                            <>
+                                {
+                                    rows?.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage).map((request, index) =>
+                                        <TableRow
+                                            key={request.requestID}
+                                            sx={{
+                                                backgroundColor: "white",
+                                                '&:last-child td:first-of-type': {
+                                                    borderBottomLeftRadius: 12,
+                                                },
+                                                '&:last-child td:last-child': {
+                                                    borderBottomRightRadius: 12,
+                                                },
+                                            }}
+                                        >
+                                            <TableCell>
+                                                {request.requestID}
+                                            </TableCell>
+                                            <TableCell>
+                                                {format(request.requestDate, "dd/MM/yyyy")}
+                                            </TableCell>
+                                            {/*Location column only renders for professionals viewing their confirmed service requests*/}
+                                            {
+                                                user.userType === UserType.PROFESSIONAL &&
+                                                <TableCell>
+                                                    <b>{request.postcode}</b>
+                                                </TableCell>
+                                            }
+                                            <TableCell>
+                                                {request.serviceType}
+                                            </TableCell>
+                                            <TableCell>
+                                                <div className={styles['status-cell']}>
+                                                    <StatusIcon status={request.requestStatus}/>
+                                                    <b>{request.requestStatus}</b>
+                                                </div>
+                                            </TableCell>
+                                            {/*Show client attached to the service request only if we are viewing as a professional*/}
+                                            {
+                                                user.userType === UserType.PROFESSIONAL &&
+                                                <TableCell>
+                                                    {request.clientName}
+                                                </TableCell>
+                                            }
+                                            <TableCell>
+                                                {request.applications?.filter((app) => app.professionalID === request.professionalID).at(0) ?
+                                                    `$${request.applications?.filter((app) => app.professionalID === request.professionalID).at(0)?.cost}` :
+                                                    '-'
                                                 }
-                                            </ThemedButton>
-                                        </TableCell>
-                                        <TableCell>
-                                            {/*    Iteration 4 work     */}
-                                        </TableCell>
-                                    </TableRow>
-                                )
-                            }
+                                            </TableCell>
+                                            <TableCell>
+                                                {/*    Mostly Iteration 3 work - only ability to view existing request implemented in 2 */}
+                                                {/* Iteration 3 will add seeing how many responses from professionals in this cell too, and more conditional rendering */}
+                                                <ThemedButton
+                                                    variantOverride={'text'}
+                                                    onClick={() => {
+                                                        setShowRequestSummary(true);
+                                                        setRequestToView(request);
+                                                    }}
+                                                >
+                                                    {
+                                                        (request.requestStatus === ServiceRequestStatus.NEW && user.userType === UserType.CLIENT) && (!request.applications || request.applications?.length === 0)
+                                                            ?
+                                                            `View / Edit` :
+                                                            `View`
+                                                    }
+                                                </ThemedButton>
+                                            </TableCell>
+                                            <TableCell>
+                                                {/*    Iteration 4 work     */}
+                                            </TableCell>
+                                        </TableRow>
+                                    )
+                                }
 
-                        </>
+                            </>
 
-                        :
+                            :
 
-                        <>
-                        </>}
-                </TableBody>
-            </Table>
+                            <>
+                            </>}
+                    </TableBody>
+                </Table>
+            </Box>
+
             <TablePagination
                 component="div"
                 count={rows?.length || 0}

--- a/src/Pages/RequestHistory/RequestHistoryTables/RequestSummary/RequestSummaryApplicantsCarousel.tsx
+++ b/src/Pages/RequestHistory/RequestHistoryTables/RequestSummary/RequestSummaryApplicantsCarousel.tsx
@@ -1,5 +1,10 @@
-import React from 'react';
-import {ServiceRequest,ServiceRequestApplication, ServiceRequestStatus, ServiceRequestApplicationStatus} from "../../../../Types/ServiceRequest";
+import React, {useState} from 'react';
+import {
+    ServiceRequest,
+    ServiceRequestApplication,
+    ServiceRequestApplicationStatus,
+    ServiceRequestStatus
+} from "../../../../Types/ServiceRequest";
 import {UserType} from "../../../../Types/Account";
 import Slider from "react-slick";
 import {Card, CardActions, CardContent, Typography} from "@mui/material";
@@ -7,20 +12,15 @@ import {ThemedButton} from "../../../../Components/Button/ThemedButton";
 import './Arrow.css';
 import {User} from "../../../../Types/User";
 import axios from 'axios';
-import {CORS_HEADER, DEV_PATH, RoutesEnum } from '../../../../Routes';
+import {CORS_HEADER, DEV_PATH, RoutesEnum} from '../../../../Routes';
 import swal from "sweetalert";
-import { useNavigate } from 'react-router-dom';
+import {useNavigate} from 'react-router-dom';
+
 export interface RequestSummaryApplicantsCarouselProps {
     /**
      * Request to display applicants for
      */
     request: ServiceRequest;
-
-
-    /**
-     * Callback to handle closing the overlay
-     */
-    setShowRequestSummary: (showRequestSummary: boolean) => void;
 
     /**
      * Cards to display on the carousel
@@ -47,18 +47,20 @@ export interface ServiceRequestApplicationCard extends ServiceRequestApplication
 }
 
 
-export const RequestSummaryApplicantsCarousel = ({   request,
-                                                     setShowRequestSummary,
+export const RequestSummaryApplicantsCarousel = ({
+                                                     request,
                                                      cards
                                                  }: RequestSummaryApplicantsCarouselProps) => {
     const user: User = JSON.parse(localStorage.getItem("user") || "{}") as User;
     const auth_token: string = JSON.parse(localStorage.getItem("auth_token") || "{}");
     const userType = user?.userType;
+
     const navigate = useNavigate();
 
+    const [loading, setLoading] = useState(false);
 
     const handleSelection = (selectedApplicationId: number) => {
-
+        setLoading(true);
         const requestSelection: Partial<ServiceRequestApplication> = {
             applicationID: selectedApplicationId,
             requestID: request.requestID,
@@ -82,7 +84,7 @@ export const RequestSummaryApplicantsCarousel = ({   request,
                 .then(() => navigate(`/${RoutesEnum.REQUEST_HISTORY}`));
         });
 
-}
+    }
 
     const listItems = cards.map((card) =>
         <li key={card.applicationID}>
@@ -114,11 +116,11 @@ export const RequestSummaryApplicantsCarousel = ({   request,
                         </Typography>
                         <CardActions style={{justifyContent: "center", display: "flex"}}>
                             <ThemedButton
+                                disabled={loading}
                                 onClick={() => handleSelection(card.applicationID)}
                             >
                                 Accept
                             </ThemedButton>
-
                         </CardActions>
                     </CardContent>
                 </Card>

--- a/src/Pages/RequestHistory/RequestHistoryTables/RequestSummaryView/RequestSummaryView.tsx
+++ b/src/Pages/RequestHistory/RequestHistoryTables/RequestSummaryView/RequestSummaryView.tsx
@@ -13,9 +13,13 @@ export interface RequestSummaryViewProps {
      * The request to view
      */
     request: ServiceRequest;
+    /**
+     * (Optional) Professional name to display, if a professional has been assigned
+     */
+    professionalName?: string;
 }
 
-export const RequestSummaryView = ({request}: RequestSummaryViewProps) => {
+export const RequestSummaryView = ({request, professionalName}: RequestSummaryViewProps) => {
     const approvedApplication: ServiceRequestApplication | undefined = request.applications?.filter((application) => application.applicationStatus === ServiceRequestApplicationStatus.APPROVED).at(0);
 
     return (
@@ -52,6 +56,16 @@ export const RequestSummaryView = ({request}: RequestSummaryViewProps) => {
                     <Typography>{`${request.requestStatus}`}</Typography>
                 </Grid>
             </Grid>
+            {professionalName &&
+                <Grid container spacing={2} marginBottom={2}>
+                    <Grid item>
+                        <Typography fontWeight={'bold'}>Assigned Professional:</Typography>
+                    </Grid>
+                    <Grid item>
+                        <Typography>{professionalName}</Typography>
+                    </Grid>
+                </Grid>
+            }
             <Grid container spacing={2} marginBottom={2}>
                 <Grid item>
                     <Typography fontWeight={'bold'}>Cost:</Typography>

--- a/src/Pages/UserProfile/EditProfile/EditProfileForm.tsx
+++ b/src/Pages/UserProfile/EditProfile/EditProfileForm.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useEffect, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {Form, Formik} from "formik";
 import * as Yup from "yup";
-import {Alert, Grid} from "@mui/material";
+import {Alert, Box, Grid} from "@mui/material";
 import {User} from "../../../Types/User";
 import {alphabeticRegExp, monthRegExp, numericRegExp, phoneRegExp,} from "../../SignUp/SignUp";
 import {EditProfileGeneral} from "./EditProfilePanels/EditProfileGeneral";
@@ -16,6 +16,8 @@ import {EditProfileClientAccount} from "./EditProfilePanels/EditProfileClientAcc
 import {CORS_HEADER, DEV_PATH, RoutesEnum} from "../../../Routes";
 import axios from "axios";
 import swal from "sweetalert";
+import {motion} from "framer-motion";
+import {fadeInUp} from "../../../Effects/Animations";
 
 export const panelStyling = {
     width: "40%",
@@ -356,7 +358,10 @@ const EditProfileForm = () => {
 
     if (user) {
         return (
-            <>
+            <Box
+                component={motion.div}
+                {...fadeInUp}
+            >
                 {alert}
                 <Formik initialValues={initialValues} validationSchema={EditSchema} onSubmit={handleSubmit}>
                     <Form>
@@ -379,7 +384,7 @@ const EditProfileForm = () => {
                         <EditProfileButtonControls handleSubmit={handleSubmit} submitting={submitting} disabled={!generalValid || !addressValid || !billingOutValid || !professionalDetailsValid}/>
                     </Form>
                 </Formik>
-            </>
+            </Box>
         );
     }
 };

--- a/src/Pages/UserProfile/ViewProfile/UserProfile.tsx
+++ b/src/Pages/UserProfile/ViewProfile/UserProfile.tsx
@@ -5,6 +5,8 @@ import {ThemedButton} from "../../../Components/Button/ThemedButton";
 import {RoutesEnum} from "../../../Routes";
 import {AccountCircleSharp, ManageAccounts} from "@mui/icons-material";
 import {User} from "../../../Types/User";
+import {motion} from "framer-motion";
+import {fadeInUp} from "../../../Effects/Animations";
 
 
 const UserProfile = () => {
@@ -13,7 +15,10 @@ const UserProfile = () => {
 
     if (user) {
         return (
-            <Box>
+            <Box
+                component={motion.div}
+                {...fadeInUp}
+            >
                 <Stack
                     sx={{
                         display: "grid"


### PR DESCRIPTION
1. Added existing fade in definition for professional profile table, request history (client + professional) tables, edit user page, view user page
2. Added in professional name (prop drilling from request summary) into the request summary view if the request status isn't new (i.e. should be assigned)
3. added a button disable when an application has been selected, and endpoint is being called (preventing user from double clicking when trying to apply)
4. Added border to segment off the request summary from 2 new sections coming in iteration 4 (Successful payment made with date + review/rating segments)