### PR TITLE
Available Requests Table Fix

### DIFF
--- a/src/Pages/AvailableRequests/AvailableRequestsTable/AvailableRequestsTable.tsx
+++ b/src/Pages/AvailableRequests/AvailableRequestsTable/AvailableRequestsTable.tsx
@@ -217,7 +217,12 @@ export const AvailableRequestsTable = () => {
                                 incomingRequests.push(serviceRequest);
                                 setServiceRequests(incomingRequests);
                             }
-                        });
+                        })
+
+                        if(serviceRequests?.length === 0 || !serviceRequests) {
+                            setLoading(false);
+                            setAlert(<></>);
+                        }
                     } else {
                         setAlert(<></>);
                         setLoading(false);
@@ -334,6 +339,7 @@ export const AvailableRequestsTable = () => {
                                     There are no service requests for this user.
                                 </Typography>
                             </TableCell>
+                            <TableCell/>
                             <TableCell/>
                             <TableCell/>
                         </TableRow> :


### PR DESCRIPTION
1. When service requests that are sent back aren't valid - doesn't stop loading - fixed
2. for empty state of this table, didn't have enough cells